### PR TITLE
FIX: Wrong order; buffer delete must come after edit.

### DIFF
--- a/plugin/file_line.vim
+++ b/plugin/file_line.vim
@@ -28,7 +28,6 @@ function! s:gotoline()
 
 	if filereadable(file_name)
 		let l:bufn = bufnr("%")
-		exec ":bwipeout " l:bufn
 
 		exec "keepalt edit " . file_name
 		exec ":" . line_num
@@ -36,9 +35,9 @@ function! s:gotoline()
 		if foldlevel(line_num) > 0
 			exec "normal! zv"
 		endif
-
-
 		exec "normal! zz"
+
+		exec ":bwipeout " l:bufn
 	endif
 
 endfunction


### PR DESCRIPTION
Commit 1d89cc7cb3b617a6701865a547a825f3d472cd3b messed up the implementation from e43d6f301d6799117770d2df0c57a7ee86fba74f. When the original buffer is deleted before the effective buffer is edited, the current window may close, thereby making a :split command appear like an :edit.
