### PR TITLE
Do bfirst after bufdo call s:gotoline()

### DIFF
--- a/plugin/file_line.vim
+++ b/plugin/file_line.vim
@@ -60,6 +60,7 @@ function s:startup()
     autocmd! BufNewFile * nested call s:gotoline()
     autocmd! BufRead * nested call s:gotoline()
     bufdo call s:gotoline()
+    bfirst
 endfunction
 
 autocmd VimEnter * call s:startup()


### PR DESCRIPTION
This resets the current buffer to the first one, so vimdiff is not
confused.
