### PR TITLE
Add silent to bufdo

### DIFF
--- a/plugin/file_line.vim
+++ b/plugin/file_line.vim
@@ -55,7 +55,7 @@ endfunction
 function s:startup()
     autocmd! BufNewFile * nested call s:gotoline()
     autocmd! BufRead * nested call s:gotoline()
-    bufdo call s:gotoline()
+    silent! bufdo call s:gotoline()
     silent! bfirst
 endfunction
 


### PR DESCRIPTION
Removes "Press ENTER or type command to continue" when opening multiple
files from the command line (vim *).
