### PR TITLE
Fix 'vim -d' to restore the current buffer

### DIFF
--- a/plugin/file_line.vim
+++ b/plugin/file_line.vim
@@ -53,10 +53,11 @@ function! s:gotoline()
 endfunction
 
 function s:startup()
+    let currBuff=bufnr("%")
     autocmd! BufNewFile * nested call s:gotoline()
     autocmd! BufRead * nested call s:gotoline()
     bufdo call s:gotoline()
-    silent! bfirst
+    silent! execute 'buffer ' . currBuff
 endfunction
 
 autocmd VimEnter * call s:startup()

--- a/plugin/file_line.vim
+++ b/plugin/file_line.vim
@@ -53,11 +53,11 @@ function! s:gotoline()
 endfunction
 
 function s:startup()
-    let currBuff=bufnr("%")
+    let l:bufn = bufnr("%")
     autocmd! BufNewFile * nested call s:gotoline()
     autocmd! BufRead * nested call s:gotoline()
     bufdo call s:gotoline()
-    silent! execute 'buffer ' . currBuff
+    silent! execute 'buffer ' . l:bufn
 endfunction
 
 autocmd VimEnter * call s:startup()


### PR DESCRIPTION
Ensure that the correct buffer gets restored. Previously, this command assumed that the current window should display the first buffer. This may not always be true.

For example, if the user's vimrc contains "autocmd VimEnter * wincmd b", then the current window is actually the last window, which causes the wrong buffer to be restored (when started in diff mode).