### PR TITLE
Use `:argdo` instead of `:bufdo` in `s:startup`

### DIFF
--- a/plugin/file_line.vim
+++ b/plugin/file_line.vim
@@ -47,20 +47,33 @@ function! s:gotoline()
 			let line_num  = l:names[2] == ''? '0' : l:names[2]
 			let  col_num  = l:names[3] == ''? '0' : l:names[3]
 			call s:reopenAndGotoLine(file_name, line_num, col_num)
-			break
+			return file_name
 		endif
 	endfor
 endfunction
 
-function s:startup()
+" Handle entry in the argument list.
+" This is called via `:argdo` when entering Vim.
+function! s:handle_arg()
+	let argname = expand('%')
+	let fname = s:gotoline()
+	if fname != argname
+		let argidx = argidx()
+		exec (argidx+1).'argdelete'
+		exec (argidx)'argadd' fname
+	endif
+endfunction
+
+function! s:startup()
 	autocmd! BufNewFile * nested call s:gotoline()
 	autocmd! BufRead * nested call s:gotoline()
-	silent! bufdo call s:gotoline()
-	silent! bfirst
-	doautocmd FileType
-	doautocmd BufEnter
-	if &diff
-		diffthis
+
+	if argc() > 0
+		let argidx=argidx()
+		argdo call s:handle_arg()
+		exec (argidx+1).'argument'
+		" Manually call Syntax autocommands, ignored by `:argdo`.
+		doautocmd Syntax
 	endif
 endfunction
 


### PR DESCRIPTION
Drop calls to `doautocmd FileType` and `doautocmd BufEnter` - only
`Syntax` needs to be called manually.
Not sure about the call to `:diffthis` for `&diff` - is `vimdiff foo:5
bar:6` supposed to work?
