### PR TITLE
Revert hooking into VimEnter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 ### Plugin for vim to enable opening a file in a given line
 
-When you open a `file:line`, for instance when coping and pasting from an error from your
-compiler vim tries to open a file with a colon in its name.
+When you open a `file:line`, for instance when coping and pasting from an error
+from your compiler vim tries to open a file with a colon in its name.
 
 Examples:
-  
+
     vim index.html:20
     vim app/models/user.rb:1337
 
-With this little script in your plugins folder if the stuff after the colon is a number and
-a file exists with the name especified before the colon vim will open this file and take you
-to the line you wished in the first place. 
+With this little script in your plugins folder if the stuff after the colon is
+a number and a file exists with the name especified before the colon vim will
+open this file and take you to the line you wished in the first place.
 
 This script is licensed with GPLv3 and you can contribute to it on github at
 [github.com/bogado/file-line](https://github.com/bogado/file-line).
@@ -22,8 +22,9 @@ This script is licensed with GPLv3 and you can contribute to it on github at
 If you use `Bundle`, add this line to your `.vimrc`:
 
     Bundle 'bogado/file-line'
-  
+
 And launch `:BundleInstall` in vim.
 
-Or just copy the file into your plugins path (`$HOME/.vim/plugin` under unixes).
+Or just copy the file into your plugins path (`$HOME/.vim/plugin` under
+unixes).
 

--- a/README.md
+++ b/README.md
@@ -2,19 +2,18 @@
 
 ### Plugin for vim to enable opening a file in a given line
 
-When you open a `file:line`, for instance when coping and pasting from an error
-from your compiler vim tries to open a file with a colon in its name.
+When you open a `file:line`, for instance when copying and pasting the output
+from a compiler, Vim tries to open a file with a colon in its name.
 
 Examples:
 
     vim index.html:20
     vim app/models/user.rb:1337
 
-With this little script in your plugins folder if the stuff after the colon is
-a number and a file exists with the name especified before the colon vim will
-open this file and take you to the line you wished in the first place.
+This plugin will handle the line number (and any column numbers) after the
+filename, taking you to the correct location.
 
-This script is licensed with GPLv3 and you can contribute to it on github at
+This script is licensed under GPLv3 and you can contribute to it on Github at
 [github.com/bogado/file-line](https://github.com/bogado/file-line).
  
 ## Install details
@@ -23,7 +22,7 @@ If you use `Bundle`, add this line to your `.vimrc`:
 
     Bundle 'bogado/file-line'
 
-And launch `:BundleInstall` in vim.
+And launch `:BundleInstall` from Vim.
 
 Or just copy the file into your plugins path (`$HOME/.vim/plugin` under
 unixes).

--- a/README.md
+++ b/README.md
@@ -27,3 +27,13 @@ And launch `:BundleInstall` from Vim.
 Or just copy the file into your plugins path (`$HOME/.vim/plugin` under
 unixes).
 
+## Configuration
+
+There is an option to control when the plugin should get used.
+
+If you want it to handle only files during Vim startup (when passing the files
+as arguments), you can use the following setting
+
+    let g:file_line_only_on_vimenter = 1
+
+The default value is 0.

--- a/plugin/file_line.vim
+++ b/plugin/file_line.vim
@@ -25,7 +25,6 @@ function! s:reopenAndGotoLine(file_name, line_num, col_num)
 		exec "normal! zv"
 	endif
 	exec "normal! zz"
-	exec "filetype detect"
 endfunction
 
 function! s:gotoline()

--- a/plugin/file_line.vim
+++ b/plugin/file_line.vim
@@ -22,9 +22,9 @@ function! s:reopenAndGotoLine(file_name, line_num, col_num)
 	exec a:line_num
 	exec "normal! " . a:col_num . '|'
 	if foldlevel(a:line_num) > 0
-		exec "normal! zv"
+		normal! zv
 	endif
-	exec "normal! zz"
+	normal! zz
 endfunction
 
 function! s:gotoline()

--- a/plugin/file_line.vim
+++ b/plugin/file_line.vim
@@ -36,7 +36,7 @@ function! s:gotoline()
 	" AutoCmd BufRead, this will test if this file actually exists before
 	" searching for a file and line to goto.
 	if (filereadable(file) || file == '')
-		return file
+		return
 	endif
 
 	let l:names = []
@@ -48,34 +48,10 @@ function! s:gotoline()
 			let line_num  = l:names[2] == ''? '0' : l:names[2]
 			let  col_num  = l:names[3] == ''? '0' : l:names[3]
 			call s:reopenAndGotoLine(file_name, line_num, col_num)
-			return file_name
+			return
 		endif
 	endfor
 endfunction
 
-" Handle entry in the argument list.
-" This is called via `:argdo` when entering Vim.
-function! s:handle_arg()
-	let argname = expand('%')
-	let fname = s:gotoline()
-	if fname != argname
-		let argidx = argidx()
-		exec (argidx+1).'argdelete'
-		exec (argidx)'argadd' fname
-	endif
-endfunction
-
-function! s:startup()
-	autocmd! BufNewFile * nested call s:gotoline()
-	autocmd! BufRead * nested call s:gotoline()
-
-	if argc() > 0
-		let argidx=argidx()
-		argdo call s:handle_arg()
-		exec (argidx+1).'argument'
-		" Manually call Syntax autocommands, ignored by `:argdo`.
-		doautocmd Syntax
-	endif
-endfunction
-
-autocmd VimEnter * call s:startup()
+autocmd! BufNewFile * nested call s:gotoline()
+autocmd! BufRead * nested call s:gotoline()

--- a/plugin/file_line.vim
+++ b/plugin/file_line.vim
@@ -52,5 +52,8 @@ function! s:gotoline()
 	endfor
 endfunction
 
-autocmd! BufNewFile * nested call s:gotoline()
-autocmd! BufRead * nested call s:gotoline()
+augroup file_line
+	au!
+	autocmd BufNewFile  * nested call s:gotoline()
+	autocmd BufReadPost * nested call s:gotoline()
+augroup END

--- a/plugin/file_line.vim
+++ b/plugin/file_line.vim
@@ -14,7 +14,9 @@ function! s:reopenAndGotoLine(file_name, line_num, col_num)
 		return
 	endif
 
-	let l:bufn = bufnr("%")
+	" Remove the original buffer when it's no longer visible.
+	" This does not break `vim -[poO]`, as with `:bwipeout`.
+	set bufhidden=wipe
 
 	exec "keepalt edit " . fnameescape(a:file_name)
 	exec a:line_num
@@ -23,8 +25,6 @@ function! s:reopenAndGotoLine(file_name, line_num, col_num)
 		exec "normal! zv"
 	endif
 	exec "normal! zz"
-
-	exec "bwipeout " l:bufn
 	exec "filetype detect"
 endfunction
 

--- a/plugin/file_line.vim
+++ b/plugin/file_line.vim
@@ -4,6 +4,10 @@ if exists('g:loaded_file_line') || (v:version < 701)
 endif
 let g:loaded_file_line = 1
 
+if !exists('g:file_line_only_on_enter')
+	let g:file_line_only_on_vimenter = 0
+endif
+
 " list with all possible expressions :
 "	 matches file(10) or file(line:col)
 "	 Accept file:line:column: or file:line:column and file:line also
@@ -28,6 +32,9 @@ function! s:reopenAndGotoLine(file_name, line_num, col_num)
 endfunction
 
 function! s:gotoline()
+	if g:file_line_only_on_vimenter && !has('vim_starting')
+		return
+	endif
 	let file = bufname("%")
 
 	" :e command calls BufRead even though the file is a new one.


### PR DESCRIPTION
This mainly reverts the hooking into VimEnter (https://github.com/bogado/file-line/commit/f74d3f55), which appears to be meant as a workaround for #11.

The proper fix for #11 appears to be using `bufhidden=wipe`, instead of wiping the buffer during the BufNewFile event, which Vim does not appear to handle properly / as expected.
