### PR TITLE
Escape filename in :argadd call

### DIFF
--- a/plugin/file_line.vim
+++ b/plugin/file_line.vim
@@ -61,7 +61,7 @@ function! s:handle_arg()
 	if fname != argname
 		let argidx = argidx()
 		exec (argidx+1).'argdelete'
-		exec (argidx)'argadd' fname
+		exec (argidx)'argadd' fnameescape(fname)
 	endif
 endfunction
 


### PR DESCRIPTION
Otherwise file names with spaces register as multiple files.