### PR TITLE
keep other autocmds, 'autocmd! -> autocmd'

### DIFF
--- a/plugin/file_line.vim
+++ b/plugin/file_line.vim
@@ -66,8 +66,8 @@ function! s:handle_arg()
 endfunction
 
 function! s:startup()
-	autocmd! BufNewFile * nested call s:gotoline()
-	autocmd! BufRead * nested call s:gotoline()
+	autocmd BufNewFile * nested call s:gotoline()
+	autocmd BufRead * nested call s:gotoline()
 
 	if argc() > 0
 		let argidx=argidx()


### PR DESCRIPTION
* fixes #47 
* fixes #61 
* clearing autocmds is not necessary, double calls are unlikely and won't cause harm

Maybe I'm missing something that needs `autocmd!`, but in my setup it's not needed and will fix the bug in #47 