### PR TITLE
Fix syntax highlighting by other plugins

### DIFF
--- a/plugin/file_line.vim
+++ b/plugin/file_line.vim
@@ -83,6 +83,7 @@ function! s:startup()
 		exec (argidx+1).'argument'
 		" Manually call Syntax autocommands, ignored by `:argdo`.
 		doautocmd Syntax
+		doautocmd FileType
 	endif
 endfunction
 


### PR DESCRIPTION
Since f74d3f550 highlighting is broken for "vim-linux-coding-style"
plugin.

bcada530d commit added "doautocmd Syntax", but erroneously dropped
"doautocmd FileType". This commit brings back FileType.

Fixes issue #64.

Was mentioned at [1].

[1] https://github.com/vivien/vim-linux-coding-style/issues/6

Signed-off-by: Sam Protsenko <joe.skb7@gmail.com>