### PR TITLE
#63: fix for syntax highlighting when opening multiple files on comma…

### DIFF
--- a/plugin/file_line.vim
+++ b/plugin/file_line.vim
@@ -79,7 +79,7 @@ function! s:startup()
 
 	if argc() > 0
 		let argidx=argidx()
-		silent argdo call s:handle_arg()
+		silent call s:handle_arg()
 		exec (argidx+1).'argument'
 		" Manually call Syntax autocommands, ignored by `:argdo`.
 		doautocmd Syntax


### PR DESCRIPTION
I don't know the details of all use cases, but removing the argdo resolves the issue for me.