### PR TITLE
Doesn't try to reopen files when no line number/column number is passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**Forked**: Same but doesn't reopen the files (can be slow), maybe introduced bugs, not sure. (`filetype detect` was what was actually slow but harder to fix).
+
 # File-line
 
 ### Plugin for vim to enable opening a file in a given line
@@ -6,23 +8,23 @@ When you open a `file:line`, for instance when coping and pasting from an error 
 compiler vim tries to open a file with a colon in its name.
 
 Examples:
-  
+
     vim index.html:20
     vim app/models/user.rb:1337
 
 With this little script in your plugins folder if the stuff after the colon is a number and
 a file exists with the name especified before the colon vim will open this file and take you
-to the line you wished in the first place. 
+to the line you wished in the first place.
 
 This script is licensed with GPLv3 and you can contribute to it on github at
 [github.com/bogado/file-line](https://github.com/bogado/file-line).
- 
+
 ## Install details
 
 If you use `Bundle`, add this line to your `.vimrc`:
 
     Bundle 'bogado/file-line'
-  
+
 And launch `:BundleInstall` in vim.
 
 Or just copy the file into your plugins path (`$HOME/.vim/plugin` under unixes).

--- a/plugin/file_line.vim
+++ b/plugin/file_line.vim
@@ -1,6 +1,6 @@
 " Avoid installing twice or when in unsupported Vim version.
 if exists('g:loaded_file_line') || (v:version < 701)
-	finish
+  finish
 endif
 let g:loaded_file_line = 1
 
@@ -17,76 +17,76 @@ let g:loaded_file_line = 1
 let s:regexpressions = [ '\(.\{-1,}\)[(:]\(\d\+\)\%(:\(\d\+\):\?\)\?' ]
 
 function! s:reopenAndGotoLine(file_name, line_num, col_num)
-	if !filereadable(a:file_name)
-		return
-	endif
+  if !filereadable(a:file_name)
+    return
+  endif
 
-	let l:bufn = bufnr("%")
+  let l:bufn = bufnr("%")
 
-	exec "keepalt edit " . fnameescape(a:file_name)
-	exec a:line_num
-	exec "normal! " . a:col_num . '|'
-	if foldlevel(a:line_num) > 0
-		exec "normal! zv"
-	endif
-	exec "normal! zz"
+  exec "keepalt edit " . fnameescape(a:file_name)
+  exec a:line_num
+  exec "normal! " . a:col_num . '|'
+  if foldlevel(a:line_num) > 0
+    exec "normal! zv"
+  endif
+  exec "normal! zz"
 
-	exec "bwipeout " l:bufn
-	exec "filetype detect"
+  exec "bwipeout " l:bufn
+  exec "filetype detect"
 endfunction
 
 function! s:gotoline()
-	let file = bufname("%")
+  let file = bufname("%")
 
-	" :e command calls BufRead even though the file is a new one.
-	" As a workaround Jonas Pfenniger<jonas@pfenniger.name> added an
-	" AutoCmd BufRead, this will test if this file actually exists before
-	" searching for a file and line to goto.
-	if (filereadable(file) || file == '')
-		return file
-	endif
+  " :e command calls BufRead even though the file is a new one.
+  " As a workaround Jonas Pfenniger<jonas@pfenniger.name> added an
+  " AutoCmd BufRead, this will test if this file actually exists before
+  " searching for a file and line to goto.
+  if (filereadable(file) || file == '')
+    return file
+  endif
 
-	let l:names = []
-	for regexp in s:regexpressions
-		let l:names =  matchlist(file, regexp)
+  let l:names = []
+  for regexp in s:regexpressions
+    let l:names =  matchlist(file, regexp)
 
-		if ! empty(l:names)
-			let file_name = l:names[1]
-			let line_num  = l:names[2] == ''? '0' : l:names[2]
-			let  col_num  = l:names[3] == ''? '0' : l:names[3]
-			call s:reopenAndGotoLine(file_name, line_num, col_num)
-			return file_name
-		endif
-	endfor
-	return file
+    if ! empty(l:names)
+      let file_name = l:names[1]
+      let line_num  = l:names[2] == ''? '0' : l:names[2]
+      let  col_num  = l:names[3] == ''? '0' : l:names[3]
+      call s:reopenAndGotoLine(file_name, line_num, col_num)
+      return file_name
+    endif
+  endfor
+  return file
 endfunction
 
 " Handle entry in the argument list.
 " This is called via `:argdo` when entering Vim.
 function! s:handle_arg()
-	let argname = expand('%')
-	let fname = s:gotoline()
-	if fname != argname
-		let argidx = argidx()
-		exec (argidx+1).'argdelete'
-		exec (argidx)'argadd' fnameescape(fname)
-	endif
+  let argname = expand('%')
+  let fname = s:gotoline()
+  if fname != argname
+    let argidx = argidx()
+    exec (argidx+1).'argdelete'
+    exec (argidx)'argadd' fnameescape(fname)
+  endif
 endfunction
 
 function! s:startup()
-	autocmd BufNewFile * nested call s:gotoline()
-	autocmd BufRead * nested call s:gotoline()
+  autocmd BufNewFile * nested call s:gotoline()
+  autocmd BufRead * nested call s:gotoline()
 
-	if argc() > 0
-		let argidx=argidx()
-		silent call s:handle_arg()
-		exec (argidx+1).'argument'
-		" Manually call Syntax autocommands, ignored by `:argdo`.
-		doautocmd Syntax
-		doautocmd FileType
-	endif
+  if argc() > 0
+    let argidx=argidx()
+    silent call s:handle_arg()
+    exec (argidx+1).'argument'
+    " Manually call Syntax autocommands, ignored by `:argdo`.
+    doautocmd Syntax
+    doautocmd FileType
+  endif
 endfunction
 
 if !isdirectory(expand("%:p"))
-	autocmd VimEnter * call s:startup()
+  autocmd VimEnter * call s:startup()
 endif


### PR DESCRIPTION
It's kind of a mess because of my comments + tabs to spaces + small things, but the interesting bit is:

```viml
  " doesn't try to reopen files
  if file_name == file
    return file
  endif
```

Which will prevent `reopenAndGotoLine` from executing `filetype detect` which can take a bit of time.

- ⚠️ Comments I added may be wrong
- ⚠️ I only tested it a little bit in my use cases
- ⚠️ This is not mergeable, it's just to show the idea
- Something else might be going on too, `if (filereadable(file) || file == '')` should stop the flow but doesn't. I'm not a viml expert :D

Thanks for such a great plugin BTW.