### PR TITLE
does not do anything with other buffers when there is only one argument passed

### DIFF
--- a/plugin/file_line.vim
+++ b/plugin/file_line.vim
@@ -80,10 +80,13 @@ function! s:startup()
 	if argc() > 0
 		let argidx=argidx()
 		silent call s:handle_arg()
-		exec (argidx+1).'argument'
-		" Manually call Syntax autocommands, ignored by `:argdo`.
-		doautocmd Syntax
-		doautocmd FileType
+
+		if argc() != 1
+			exec (argidx+1).'argument'
+			" Manually call Syntax autocommands, ignored by `:argdo`.
+			doautocmd Syntax
+			doautocmd FileType
+		endif
 	endif
 endfunction
 


### PR DESCRIPTION
Not sure what `exec (argidx+1).'argument'` does but it seems related to handling multiple arguments and everything works fine when only one file is passed.

Obviously testing was limited but this did reduce startup time for my rails-related file from ~0.8s to ~0.1s (not actual measurements :) ).