### PR TITLE
Allow opening files with garbage behing colon

### DIFF
--- a/plugin/file_line.vim
+++ b/plugin/file_line.vim
@@ -14,7 +14,7 @@ let g:loaded_file_line = 1
 " closing braces/colons are ignored, so also acceptable are:
 " * code.cc(10
 " * code.cc:10:
-let s:regexpressions = [ '\(.\{-1,}\)[(:]\(\d\+\)\%(:\(\d\+\):\?\)\?' ]
+let s:regexpressions = [ '\(.\{-1,}\)[(:]\(\d*\)\%(:\(\d\+\):\?\)\?', ]
 
 function! s:reopenAndGotoLine(file_name, line_num, col_num)
 	if !filereadable(a:file_name)


### PR DESCRIPTION
E.g if someone does a grep and gets output like this:

```
$ grep -r TODO
myfile:TODO add some stuff
otherfile:TODO other stuff
```

Then I like to just choose a file by double clicking the name and writing e.g. `vim myfile:TODO` without having to erase the TODO bit.

This is accomplished by allowing zero digits in the line number.